### PR TITLE
Allow user defined schemas

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/ecmwf-projects/cookiecutter-conda-package",
-  "commit": "c7cd369f71b4cfc647fc7c1972cc3c45860256d5",
+  "commit": "baa719b04376f091dee7b3f221d3b62eb29d2f95",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -10,6 +10,7 @@
       "copyright_holder": "European Centre for Medium Range Weather Forecasts",
       "copyright_year": "2023",
       "mypy_strict": "False",
+      "integration_tests": false,
       "_template": "https://github.com/ecmwf-projects/cookiecutter-conda-package"
     }
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,34 +90,34 @@ jobs:
       run: |
         echo type-check not used
 
-  # documentation:
-  #   needs: [unit-tests]
-  #   if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       shell: bash -l {0}
+  documentation:
+    needs: [unit-tests]
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
 
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #     with:
-  #       ref: ${{ github.event.pull_request.head.sha || github.ref }}
-  #   - name: Install Conda environment with Micromamba
-  #     uses: mamba-org/provision-with-micromamba@v12
-  #     with:
-  #       environment-file: environment.yml
-  #       environment-name: DEVELOP
-  #       channels: conda-forge
-  #       cache-env: true
-  #       cache-env-key: ubuntu-latest-3.10
-  #       extra-specs: |
-  #         python=3.10
-  #   - name: Install package
-  #     run: |
-  #       python -m pip install --no-deps -e .
-  #   - name: Build documentation
-  #     run: |
-  #       make docs-build
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@v12
+      with:
+        environment-file: environment.yml
+        environment-name: DEVELOP
+        channels: conda-forge
+        cache-env: true
+        cache-env-key: ubuntu-latest-3.10
+        extra-specs: |
+          python=3.10
+    - name: Install package
+      run: |
+        python -m pip install --no-deps -e .
+    - name: Build documentation
+      run: |
+        make docs-build
 
   integration-tests:
     needs: [unit-tests]

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,62 @@ version.py
 # Sphinx automatic generation of API
 docs/_api/
 
-# Created by https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vim,visualstudiocode,pycharm
-# Edit at https://www.toptal.com/developers/gitignore?templates=python,jupyternotebooks,vim,visualstudiocode,pycharm
+# Combined environments
+ci/combined-environment-*.yml
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vim,visualstudiocode,pycharm,emacs,linux,macos,windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,jupyternotebooks,vim,visualstudiocode,pycharm,emacs,linux,macos,windows
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
 
 ### JupyterNotebooks ###
 # gitignore template for Jupyter Notebooks
@@ -20,6 +74,52 @@ ipython_config.py
 
 # Remove previous ipynb_checkpoints
 #   git rm -r .ipynb_checkpoints/
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
 
 ### PyCharm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
@@ -147,7 +247,6 @@ __pycache__/
 .Python
 build/
 develop-eggs/
-dist/
 downloads/
 eggs/
 .eggs/
@@ -293,6 +392,16 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]
@@ -308,7 +417,6 @@ Sessionx.vim
 
 # Temporary
 .netrwhist
-*~
 # Auto-generated tag files
 tags
 # Persistent undo
@@ -316,6 +424,8 @@ tags
 
 ### VisualStudioCode ###
 .vscode/
+.DS_Store
+docs/.DS_Store
 # .vscode/*
 # !.vscode/settings.json
 # !.vscode/tasks.json
@@ -334,10 +444,30 @@ tags
 .history
 .ionide
 
-# Support for Project snippet scope
-.vscode/*.code-snippets
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
 
-# Ignore code-workspaces
-*.code-workspace
+# Dump file
+*.stackdump
 
-# End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vim,visualstudiocode,pycharm
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vim,visualstudiocode,pycharm,emacs,linux,macos,windows

--- a/.pre-commit-config-weekly.yaml
+++ b/.pre-commit-config-weekly.yaml
@@ -1,7 +1,0 @@
-repos:
-- repo: https://github.com/cruft/cruft
-  rev: 2.12.0
-  hooks:
-  - id: cruft
-    entry: cruft update -y
-    additional_dependencies: [toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -23,26 +23,19 @@ repos:
   hooks:
   - id: blackdoc
     additional_dependencies: [black==22.3.0]
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.3
   hooks:
-  - id: flake8
+  - id: ruff
+    args: [--fix, --show-fixes]
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.16
+  rev: 0.7.17
   hooks:
   - id: mdformat
-    exclude: cruft-update-template.md
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.5.0
+  rev: v2.11.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --preserve-quotes]
   - id: pretty-format-toml
     args: [--autofix]
-    additional_dependencies: [toml-sort<0.22.0]
-- repo: https://github.com/PyCQA/pydocstyle.git
-  rev: 6.1.1
-  hooks:
-  - id: pydocstyle
-    additional_dependencies: [toml]
-    exclude: tests|docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+formats: []
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ docker-run:
 	docker run --rm -ti -v $(PWD):/srv $(PROJECT)
 
 template-update:
-	pre-commit run --all-files cruft -c .pre-commit-config-weekly.yaml
+	pre-commit run --all-files cruft -c .pre-commit-config-cruft.yaml
 
 docs-build:
 	cd docs && rm -fr _api && make clean && make html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,8 @@ release = "0.0.0"  # earthkit.maps.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_rtd_theme",
+    "nbsphinx",
     # "autoapi.extension",
     # "myst_parser",
     # "sphinx.ext.autodoc",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,14 @@
+# These are the requirements for readthedocs
+ipykernel
+docutils
+Pygments>=2.6.1
+Sphinx
+sphinx-rtd-theme
+nbsphinx
+setuptools
+sphinx-autoapi
+entrypoints
+pandas
+tqdm
+xarray
+filelock

--- a/earthkit/maps/domains/domain.py
+++ b/earthkit/maps/domains/domain.py
@@ -124,9 +124,9 @@ class Domain:
 
     @property
     def title(self):
-        if self.domain_name in DOMAIN_LOOKUP["the_countries"]:
-            return f"the {self.domain_name}"
-        elif self.domain_name is None:
+        # if self.domain_name in DOMAIN_LOOKUP["the_countries"]:
+        #     return f"the {self.domain_name}"
+        if self.domain_name is None:
             if self.bounds is None:
                 string = "custom domain"
             else:

--- a/earthkit/maps/layers/subplots.py
+++ b/earthkit/maps/layers/subplots.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import cartopy.io.shapereader as shpreader
@@ -130,6 +131,7 @@ class Subplot:
                     x, y, values = extract_reduced_gg(data, self.domain)
                     kwargs.pop("transform_first", None)
                     transform = self.domain.crs
+
                 else:
                     x, y, values = extract_scalar(data, self.domain)
                 if transform is None:
@@ -261,6 +263,9 @@ class Subplot:
         return style.contourf(self.ax, *args, **kwargs)
 
     def _tricontourf(self, *args, style=None, **kwargs):
+
+        kwargs.pop("transform", None)
+
         return style.tricontourf(self.ax, *args, **kwargs)
 
     @polygonal

--- a/earthkit/maps/layers/superplots.py
+++ b/earthkit/maps/layers/superplots.py
@@ -422,10 +422,10 @@ class Superplot:
         self._release_queue()
         plt.show(*args, **kwargs)
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, bbox_inches="tight", **kwargs):
         """Save the chart."""
         if len(self) == 0:
             self._rows, self._cols = (1, 1)
             self.add_subplot()
         self._release_queue()
-        return plt.savefig(*args, **kwargs)
+        return plt.savefig(*args, bbox_inches=bbox_inches, **kwargs)

--- a/earthkit/maps/schemas.py
+++ b/earthkit/maps/schemas.py
@@ -156,14 +156,18 @@ class Schema(dict):
         Parameters
         ----------
         name : str
-            The name of the schema to use.
+            The name of the schema to use, or path to 
+            user implemented schema.
 
         Example
         -------
         >>> schema.use("default")
+        >>> schema.use("~/custom.yaml")
         """
         file_name = definitions.SCHEMA_DIR / f"{name}.yaml"
         if not os.path.exists(file_name):
+            if os.path.exists(name):
+                file_name = name
             raise SchemaNotFoundError(f"no schema '{name}' found")
         with open(file_name, "r") as f:
             kwargs = yaml.load(f, Loader=yaml.SafeLoader)

--- a/earthkit/maps/schemas.py
+++ b/earthkit/maps/schemas.py
@@ -168,7 +168,8 @@ class Schema(dict):
         if not os.path.exists(file_name):
             if os.path.exists(name):
                 file_name = name
-            raise SchemaNotFoundError(f"no schema '{name}' found")
+            else:
+                raise SchemaNotFoundError(f"no schema '{name}' found")
         with open(file_name, "r") as f:
             kwargs = yaml.load(f, Loader=yaml.SafeLoader)
         self._reset(**kwargs)

--- a/earthkit/maps/styles/__init__.py
+++ b/earthkit/maps/styles/__init__.py
@@ -32,12 +32,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_LEGEND_LABEL = "{variable_name} ({units})"
 
 
-def auto_range(data, n_levels=8):
+def auto_range(data, divergence_point=None, n_levels=8):
 
     if isinstance(data, earthkit.data.core.Base):
         data = data.to_numpy()
     min_value = np.nanmin(data)
     max_value = np.nanmax(data)
+
+    if divergence_point == 0:
+        abs_max = max(abs(min_value), abs(max_value))
+        min_value = -abs_max
+        max_value = abs_max
 
     data_range = max_value - min_value
 
@@ -113,6 +118,7 @@ class Style:
         self,
         colors="auto",
         levels=None,
+        divergence_point=None,
         level_step=None,
         level_multiple=None,
         units=None,
@@ -134,6 +140,7 @@ class Style:
         self._levels = levels
         self._level_step = level_step
         self._level_multiple = level_multiple
+        self._divergence_point = divergence_point
 
         self.legend_type = legend_type
 
@@ -181,7 +188,7 @@ class Style:
     def levels(self, data):
         if self._levels is None:
             if self._level_step is None:
-                return auto_range(data)
+                return auto_range(data, self._divergence_point)
             else:
                 return step_range(data, self._level_step, self._level_multiple)
         return self._levels

--- a/earthkit/maps/styles/anomalies.py
+++ b/earthkit/maps/styles/anomalies.py
@@ -1,0 +1,21 @@
+# Copyright 2023, European Centre for Medium Range Weather Forecasts.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from earthkit.maps import styles
+
+ANOMALY = styles.Contour(
+    colors=["#08306b", "#08519c", "#f9fbfd", "#fff7ec", "#e94b0d", "#7f0000"],
+    gradients=[30, 90, 0, 90, 30],  # the number of bins between each level
+)

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,6 @@ dependencies:
 - pydata-sphinx-theme
 - pytest
 - pytest-cov
-- sphinx
-- sphinx-autoapi
 # DO NOT EDIT ABOVE THIS LINE, ADD DEPENDENCIES BELOW
 - earthkit-data
 - pandas
@@ -22,3 +20,11 @@ dependencies:
 - xarray
 - cf-units
 - scipy
+- sphinx>=7.2.6
+- pip:
+  - sphinx-autoapi>=3.0.0
+- sphinx_rtd_theme
+- sphinxcontrib-apidoc
+- nbformat
+- nbconvert
+- nbsphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ branch = true
 profile = "black"
 
 [tool.pydocstyle]
-convention = "numpy"
 add_ignore = "D1"
+convention = "numpy"
 
 [tool.setuptools_scm]
 write_to = "earthkit/maps/version.py"


### PR DESCRIPTION
Extend `schema.use` to allow for paths to user defined schemas.

## Reasoning
While standard schemas allow a consistent look across groups, it may be desired by others to define their own layout.
This will require more documentation, e.g. what can be included in a schema. But this allows a developer to use their own layout.

